### PR TITLE
release: v1.8.0 — multi-source citation confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes are documented in this file.
 
 ## Unreleased
 
+## 1.8.0 - 2026-08-22
+
 ### Added
 - **Claim-level citation verification** (`engine/utils/citation_claim_verifier.py`).
   Judges whether a citation is topically relevant to the claim it is attached

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.4"
+version = "1.8.0"
 description = "Generate master-level research papers with real citations in minutes"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.4"
+version = "1.8.0"
 description = "Open-source AI research draft generator with 19 specialized agents and verified citations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Cuts the ready CHANGELOG `Unreleased` block as **v1.8.0** and bumps the package version (root + engine pyproject) from 1.7.4.

Ships the claim-level citation verification + multi-source DOI confirmation feature merged in #64: a citation is kept only if 2+ of {Crossref, OpenAlex, Semantic Scholar} independently hold its DOI, LLM-fallback is off by default, and every citation carries a `verification_status`.

Version bump + changelog rename only — no code change. Publishing the GitHub Release for the resulting tag triggers the trusted-publisher PyPI upload of 1.8.0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>